### PR TITLE
Clarify encoding length in performance.rst

### DIFF
--- a/src/docs/src/maintenance/performance.rst
+++ b/src/docs/src/maintenance/performance.rst
@@ -248,8 +248,8 @@ go from 21GB to 4GB with 10 million documents (the raw JSON text when from
 Inserting with sequential (and at least sorted) ids is faster than random ids.
 Consequently you should consider generating ids yourself, allocating them
 sequentially and using an encoding scheme that consumes fewer bytes.
-For example, something that takes 16 hex digits to represent can be done in
-4 base 62 digits (10 numerals, 26 lower case, 26 upper case).
+For example, 8 bytes will take 16 hex digits to represent, and those same
+8 bytes can be encoded in only 11 digits/chars in base64url (no padding).
 
 Views
 =====


### PR DESCRIPTION
The original text said that something that takes 16 hex digits can be represented with just 4 digits (in an hypothetical base62 encoding).

I believe that was a typo since 16 hex digits encode a 8-byte sequence that will require (8/3)*4 = 11 digits in base64 (without padding).

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This is a documentation change that fix what I believe was a typo. 
I also rephrased it , so that it's more clear (IMHO)

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

This is a documentation change, so I don't think it applies 

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches

**I don't think the checklist applies to documentation changes. **
